### PR TITLE
Nova client changes for delete on termination flags

### DIFF
--- a/novaclient/base.py
+++ b/novaclient/base.py
@@ -152,9 +152,12 @@ class Manager(base.HookableMixin):
         if cache:
             cache.write("%s\n" % val)
 
-    def _get(self, url, response_key):
+    def _get(self, url, response_key=None):
         _resp, body = self.api.client.get(url)
-        return self.resource_class(self, body[response_key], loaded=True)
+        if response_key:
+            return self.resource_class(self, body[response_key], loaded=True)
+        else:
+            return self.resource_class(self, body, loaded=True)
 
     def _create(self, url, body, response_key, return_raw=False, **kwargs):
         self.run_hooks('modify_body_for_create', body, **kwargs)

--- a/novaclient/v2/volumes.py
+++ b/novaclient/v2/volumes.py
@@ -112,6 +112,26 @@ class VolumeManager(base.ManagerWithFind):
         with self.alternate_service_type('volume'):
             self._delete("/volumes/%s" % base.getid(volume))
 
+    def show_delete_on_termination_flag(self, volume_id):
+        """
+        Get the delete on termination flag on the volume id
+        to the given value.
+
+        :param volume_id: The ID of the volume to update
+        """
+        return self._get("/volumes/%s" % volume_id)
+
+    def update_delete_on_termination_flag(self, volume_id, flag):
+        """
+        Set the delete on termination flag on the volume id
+        to the given value.
+
+        :param volume_id: The ID of the volume to update
+        :param flag: True/False
+        """
+        body = {"delete_on_termination": flag}
+        return self._update("/volumes/%s" % volume_id, body)
+
     def create_server_volume(self, server_id, volume_id, device):
         """
         Attach a volume identified by the volume ID to the given server ID


### PR DESCRIPTION
Adding changes in novaclient for delete on termination APIs. Tested on devstack with boto and the python client.
